### PR TITLE
conversation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ mount Phlex::Chatbot::Web, at: "/phlex-chatbot"
 Create an initializer `config/initializers/phlex_chatbot.rb` to set your logger:
 ```ruby
 Phlex::Chatbot.logger = Rails.logger
-Phlex::Chatbot.contextualizer = ... <a subclass of Phlex::Chatbot::Contextualizer, see below>
+Phlex::Chatbot.conversator = ... <a subclass of Phlex::Chatbot::Conversator, see below>
 Phlex::Chatbot.disallow_error_messages! # if you don't want Ruby error messages shown in the bot UI (default)
 Phlex::Chatbot.allow_error_messages! # if you want Ruby error messages shown in the bot UI
 ```
@@ -83,15 +83,15 @@ Your application is responsible for determining how to respond to that new messa
 sends the chatbot a status message, processes the incoming message using `langchainrb` and `ruby-openai`, and
 finally sends a final response.
 
-Your application is responsible for setting the `Phlex::Chatbot.contextualizer` which is a subclass of
-`Phlex::Chatbot::Contextualizer`. At a minimum, you should implement `#call(bot, incoming_message, bot_id)`.
+Your application is responsible for setting the `Phlex::Chatbot.conversator` which is a subclass of
+`Phlex::Chatbot::Conversator`. At a minimum, you should implement `#call(bot, incoming_message, bot_id)`.
 You can also implement the `#contextualize` message that is responsible for adding more context to the mesasge
 that gets sent to the bot's UI. Specifically, it should add the `user_name` and `avatar` keys to the message
 hash (as symbols) based on whether the message is from the bot or the person with whom the bot is conversing.
 The base implementation adds some basic defaults.
 
 ```ruby
-Phlex::Chatbot.contextualizer = Class.new(Phlex::Chatbot::Contextualizer) do
+Phlex::Chatbot.conversator = Class.new(Phlex::Chatbot::Conversator) do
   def call(bot, incoming_message, bot_id)
     bot.send_status!(message: "I got your message, just a sec...")
 
@@ -108,7 +108,7 @@ This example uses a custom class and the excellent [Sequel](https://sequel.jerem
 full text search for the top 10 results matching the incoming message.
 
 ```ruby
-class FullTextSearch < Phlex::Chatbot::Contextualizer
+class FullTextSearch < Phlex::Chatbot::Conversator
   SYSTEM_NAME = 'My Bot'
 
   def call(bot, incoming_message, bot_id)

--- a/README.md
+++ b/README.md
@@ -129,6 +129,22 @@ You can converse with your chatbot in three ways:
 1. `#send_failure!` - similar to `#send_response!` this will replace the bot's temporary response but allows
    the UI to style the response differently, indicating to the user that something unexpected has occured
 
+### Channel#send_status!
+This message receives a `String` which is broadcast to all chat subscribers. The chatbot will change the title
+of the bot response placeholder with this message. It is expected that the "backend" will either broadcast
+a final response or a failure at some point after this.
+
+### Channel#send_response!
+This message receives `message: String` and `sources: Array<String>`.
+  - `message: String` - the message you want to broadcast to all chat subscribers. Sources can be link with the
+    pattern `[1]`, `[2]`, `[3]`, etc. These text patterns will be replaced with the corresponding source from
+    the `sources` argument, if supplied. The links are one-based, not zero-based.
+  - `sources: Array<String>` - links to source data in the `message`
+
+### Channel#send_failure!
+This message receives an Exception object. Its `message` is broadcast to all chat subscribers. This will cause
+the chatbot placeholder to be finalized with this message. No other response is needed after this point.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/phlex/chatbot.rb
+++ b/lib/phlex/chatbot.rb
@@ -6,6 +6,7 @@ require "rack"
 
 require_relative "chatbot/channel"
 require_relative "chatbot/chat"
+require_relative "chatbot/contextualizer"
 require_relative "chatbot/null_logger"
 require_relative "chatbot/status_component"
 require_relative "chatbot/switchboard/base"
@@ -17,12 +18,25 @@ module Phlex
     class Error < StandardError; end
     ROOT_DIR = Pathname.new(__dir__).join("../..").expand_path
 
-    def self.callback
-      @callback
+    def self.allow_error_messages?
+      @allow_error_messages
     end
 
-    def self.callback=(callback)
-      @callback = callback
+    def self.allow_error_messages!
+      @allow_error_messages = true
+    end
+
+    def self.contextualizer(channel_id:)
+      @contextualizer.create(channel_id)
+    end
+
+    def self.contextualizer=(contextualizer)
+      @contextualizer = contextualizer
+    end
+    self.contextualizer = Phlex::Chatbot::Contextualizer
+
+    def self.disallow_error_messages!
+      @allow_error_messages = false
     end
 
     def self.logger
@@ -36,7 +50,7 @@ module Phlex
     def self.switchboard
       @switchboard ||= "in_memory"
       require_relative "chatbot/switchboard/#{@switchboard}"
-      cls_name = @switchboard.to_s.split('_').map(&:capitalize).join
+      cls_name = @switchboard.to_s.split("_").map(&:capitalize).join
       Switchboard.const_get(cls_name).instance
     end
 

--- a/lib/phlex/chatbot.rb
+++ b/lib/phlex/chatbot.rb
@@ -6,7 +6,7 @@ require "rack"
 
 require_relative "chatbot/channel"
 require_relative "chatbot/chat"
-require_relative "chatbot/contextualizer"
+require_relative "chatbot/conversator"
 require_relative "chatbot/null_logger"
 require_relative "chatbot/status_component"
 require_relative "chatbot/switchboard/base"
@@ -26,14 +26,14 @@ module Phlex
       @allow_error_messages = true
     end
 
-    def self.contextualizer(channel_id:)
-      @contextualizer.create(channel_id)
+    def self.conversator(channel_id:)
+      @conversator.create(channel_id)
     end
 
-    def self.contextualizer=(contextualizer)
-      @contextualizer = contextualizer
+    def self.conversator=(conversator)
+      @conversator = conversator
     end
-    self.contextualizer = Phlex::Chatbot::Contextualizer
+    self.conversator = Phlex::Chatbot::Conversator
 
     def self.disallow_error_messages!
       @allow_error_messages = false

--- a/lib/phlex/chatbot/channel.rb
+++ b/lib/phlex/chatbot/channel.rb
@@ -6,51 +6,62 @@ require_relative "client/web_socket"
 module Phlex
   module Chatbot
     class Channel
-      attr_reader :callback, :clients, :channel_id
+      attr_reader :contextualizer, :clients, :channel_id
 
-      def initialize(channel_id, callback)
-        @callback   = callback
-        @channel_id = channel_id
-        @clients    = Concurrent::Set.new
+      def initialize(channel_id, contextualizer)
+        @contextualizer = contextualizer
+        @channel_id   = channel_id
+        @clients      = Concurrent::Set.new
       end
 
       def send_ack!(message:)
-        send_event(:resp, data: [{ cmd: "append", element: Chat::Message.new(message: message, from_user: true).call }])
+        args = contextualizer.contextualize(message: message, from_user: true)
+        send_event(:resp, data: [{ cmd: "append", element: Chat::Message.new(**args).call }])
       end
 
       def send_failure!(error)
         Chatbot.logger.error error
+        message = if error.respond_to?(:message) && Phlex::Chatbot.allow_error_messages?
+                    error.message
+                  elsif error.is_a?(String)
+                    error
+                  else
+                    "An error occurred"
+                  end
+        args = contextualizer.contextualize(message: message, from_user: false)
         send_event(
           :resp,
           data: [
             { cmd: "delete", selector: "#current_status" },
-            { cmd: "append", element: Chat::Message.new(message: error.message).call },
+            { cmd: "append", element: Chat::Message.new(**args).call },
           ],
         )
       end
 
       def send_response!(message:, sources: nil)
+        args = contextualizer.contextualize(message: message, from_user: false, sources: sources)
         send_event(
           :resp,
           data: [
             { cmd: "delete", selector: "#current_status" },
-            { cmd: "append", element: Chat::Message.new(message: message, sources: sources).call },
+            { cmd: "append", element: Chat::Message.new(**args).call },
           ],
         )
       end
 
       def send_status!(message:)
+        args = contextualizer.contextualize(message: message, from_user: false)
         send_event(
           :resp,
           data: [
             { cmd: "delete", selector: "#current_status" },
-            { cmd: "append", element: ChatbotThinking.new(message).call },
+            { cmd: "append", element: ChatbotThinking.new(**args).call },
           ],
         )
       end
 
       def start_conversation!(data)
-        callback.call(self, data)
+        contextualizer.call(self, data, channel_id)
       rescue StandardError => e
         send_failure!(e)
       end

--- a/lib/phlex/chatbot/chat/message.rb
+++ b/lib/phlex/chatbot/chat/message.rb
@@ -6,9 +6,10 @@ module Phlex
   module Chatbot
     module Chat
       class Message < Phlex::HTML
-        attr_reader :from_user, :message, :sources, :status_message, :user_name
+        attr_reader :avatar, :from_user, :message, :sources, :status_message, :user_name
 
-        def initialize(message:, from_user: false, sources: nil, user_name: nil, status_message: nil)
+        def initialize(message:, avatar: nil, from_user: false, sources: nil, user_name: nil, status_message: nil) # rubocop:disable Metrics/ParameterLists
+          @avatar         = avatar
           @from_user      = from_user
           @message        = message
           @sources        = sources
@@ -28,7 +29,7 @@ module Phlex
           ) do
             div(class: "pcb__status-indicator") { status_message } if status_message
 
-            render UserIdentifier.new(from_system: !from_user, user_name: user_name)
+            render UserIdentifier.new(avatar: avatar, from_system: !from_user, user_name: user_name)
 
             div class: "pcb__message__content" do
               if block_given?

--- a/lib/phlex/chatbot/chat/user_identifier.rb
+++ b/lib/phlex/chatbot/chat/user_identifier.rb
@@ -6,7 +6,8 @@ module Phlex
       class UserIdentifier < Phlex::HTML
         AI_ASST = "AI Assistant"
 
-        def initialize(user_name: nil, from_system: false)
+        def initialize(avatar: nil, user_name: nil, from_system: false)
+          @avatar        = avatar
           @from_system   = from_system
           @user_name     = user_name || (from_system ? AI_ASST : "Visitor")
           @user_nickname = @user_name == AI_ASST ? "AI" : @user_name.split.map(&:chr).join.upcase
@@ -14,9 +15,14 @@ module Phlex
 
         def view_template
           div class: "pcb__user-identifier" do
-            div(**classes("pcb__user-identifier-avatar", from_system?: "pcb__user-identifier-avatar__bot",
-from_user?: "pcb__user-identifier-avatar__user")) do
-              @user_nickname
+            div(
+              **classes(
+                "pcb__user-identifier-avatar",
+                from_system?: "pcb__user-identifier-avatar__bot",
+                from_user?: "pcb__user-identifier-avatar__user",
+              ),
+            ) do
+              @avatar || @user_nickname
             end
             span(class: "pcb__user-identifier-name") { @user_name }
           end

--- a/lib/phlex/chatbot/contextualizer.rb
+++ b/lib/phlex/chatbot/contextualizer.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Phlex
+  module Chatbot
+    class Contextualizer
+      attr_reader :system_avatar, :system_name, :user_avatar, :user_name
+
+      def self.create(_channel_id)
+        new
+      end
+
+      def initialize(system_name: "AI Assistant", system_avatar: nil, user_name: "Visitor", user_avatar: nil, &blk)
+        @system_name   = system_name
+        @system_avatar = system_avatar
+        @user_name     = user_name
+        @user_avatar   = user_avatar
+        @callback      = blk
+      end
+
+      def contextualize(hash)
+        if hash[:from_user]
+          hash.merge(user_name: user_name, avatar: user_avatar)
+        else
+          hash.merge(user_name: system_name, avatar: system_avatar)
+        end
+      end
+
+      def call(bot, data, channel_id)
+        @callback.call(bot, data, channel_id)
+      end
+    end
+  end
+end

--- a/lib/phlex/chatbot/conversator.rb
+++ b/lib/phlex/chatbot/conversator.rb
@@ -2,7 +2,7 @@
 
 module Phlex
   module Chatbot
-    class Contextualizer
+    class Conversator
       attr_reader :system_avatar, :system_name, :user_avatar, :user_name
 
       def self.create(_channel_id)

--- a/lib/phlex/chatbot/switchboard/base.rb
+++ b/lib/phlex/chatbot/switchboard/base.rb
@@ -3,13 +3,12 @@
 module Phlex
   module Chatbot
     module Switchboard
-
       def self.converse(channel_id, message)
         Phlex::Chatbot.switchboard.converse(channel_id, message)
       end
 
       def self.create(id)
-        Phlex::Chatbot.switchboard.create(Digest::SHA256.hexdigest(id))
+        Phlex::Chatbot.switchboard.create(id.to_s)
       end
 
       def self.destroy(channel_id)

--- a/lib/phlex/chatbot/switchboard/in_memory.rb
+++ b/lib/phlex/chatbot/switchboard/in_memory.rb
@@ -9,7 +9,7 @@ module Phlex
         include Singleton
 
         def initialize
-          @channels ||= Concurrent::Hash.new
+          @channels = Concurrent::Hash.new
         end
 
         def create(channel_id)

--- a/lib/phlex/chatbot/switchboard/in_memory.rb
+++ b/lib/phlex/chatbot/switchboard/in_memory.rb
@@ -13,10 +13,10 @@ module Phlex
         end
 
         def create(channel_id)
-          (channels[channel_id] ||= Channel.new(channel_id, Phlex::Chatbot.callback)).channel_id
+          (channels[channel_id] ||= Channel.new(channel_id)).channel_id
         end
 
-        def extend_ttl(channel_id)
+        def extend_ttl(_channel_id)
           nil
         end
 

--- a/lib/phlex/chatbot/switchboard/redis.rb
+++ b/lib/phlex/chatbot/switchboard/redis.rb
@@ -24,11 +24,7 @@ module Phlex
 
         def create(channel_id)
           extend_ttl(channel_id) || @redis_db.setex(channel_id, TEN_MINUTES, true)
-          (channels[channel_id] ||= ChannelWrapper.new(
-            channel_id,
-            Phlex::Chatbot.contextualizer(channel_id: channel_id),
-            @subscriber,
-          )).channel_id
+          (channels[channel_id] ||= ChannelWrapper.new(channel_id, @subscriber)).channel_id
         end
 
         def extend_ttl(channel_id)
@@ -41,16 +37,12 @@ module Phlex
             return
           end
 
-          channels[channel_id] ||= ChannelWrapper.new(
-            channel_id,
-            Phlex::Chatbot.contextualizer(channel_id: channel_id),
-            @subscriber,
-          )
+          channels[channel_id] ||= ChannelWrapper.new(channel_id, @subscriber)
         end
 
         class ChannelWrapper < Channel
-          def initialize(channel_id, callback, subscriber)
-            super(channel_id, callback)
+          def initialize(channel_id, subscriber)
+            super(channel_id)
 
             @redis_subscriber = subscriber
           end

--- a/lib/phlex/chatbot/switchboard/redis.rb
+++ b/lib/phlex/chatbot/switchboard/redis.rb
@@ -22,9 +22,13 @@ module Phlex
           @subscriber = RedisSubscriber.spawn(name: :redis_subscriber)
         end
 
-        def create(id)
-          extend_ttl(id) || @redis_db.setex(id, TEN_MINUTES, true)
-          (channels[id] ||= ChannelWrapper.new(id, Phlex::Chatbot.callback, @subscriber)).channel_id
+        def create(channel_id)
+          extend_ttl(channel_id) || @redis_db.setex(channel_id, TEN_MINUTES, true)
+          (channels[channel_id] ||= ChannelWrapper.new(
+            channel_id,
+            Phlex::Chatbot.contextualizer(channel_id: channel_id),
+            @subscriber,
+          )).channel_id
         end
 
         def extend_ttl(channel_id)
@@ -37,7 +41,11 @@ module Phlex
             return
           end
 
-          channels[channel_id] ||= ChannelWrapper.new(channel_id, Phlex::Chatbot.callback, @subscriber)
+          channels[channel_id] ||= ChannelWrapper.new(
+            channel_id,
+            Phlex::Chatbot.contextualizer(channel_id: channel_id),
+            @subscriber,
+          )
         end
 
         class ChannelWrapper < Channel

--- a/src/javascript/controllers/chat_form_controller.js
+++ b/src/javascript/controllers/chat_form_controller.js
@@ -232,6 +232,7 @@ export default class extends Controller {
   }
 
   url(action) {
-    return `${this.endpointValue}/${action}/${this.conversationTokenValue}`
+    const encodedToken = encodeURIComponent(this.conversationTokenValue);
+    return `${this.endpointValue}/${action}/${encodedToken}`
   }
 }


### PR DESCRIPTION
This fundamentally changes how the bot converses with its initiator. Instead of a simple callback (anything that responds to `#call`) conversations must now happen via the `Phlex::Chatbot::Contextualizer` or a subclass. The API of the contextualizer is `#call` (for the conversing) and `#contextualize` to allow the initiator to add more context to the responses sent to the bot UI.